### PR TITLE
Fixed bug with nested Run blocks

### DIFF
--- a/pbench.go
+++ b/pbench.go
@@ -47,7 +47,7 @@ func (b *B) Run(name string, f func(b *B)) bool {
 	defer b.report()
 
 	return b.B.Run(name, func(tb *testing.B) {
-		subB, cpus := &B{B: tb, percs: b.percs}, runtime.GOMAXPROCS(-1)
+		subB, cpus := &B{B: tb, percs: b.percs, subBs: map[int]*B{}}, runtime.GOMAXPROCS(-1)
 		b.subBs[cpus] = subB
 		b.cpus = append(b.cpus, cpus)
 		f(subB)


### PR DESCRIPTION
I've been using your package for a project I'm working on at work. I found a bug when nesting Run blocks, which can be reproduced like so:
```
func BenchmarkABC(tb *testing.B) {
	b := pbench.New(tb)
	b.ReportPercentile(0.99)

	b.Run("D", func(b *pbench.B) {
		b.Run("E", func(b *pbench.B) {
			b.RunParallel(func(pb *pbench.PB) {
				for pb.Next() {
					fmt.Print(".")
					time.Sleep(100 * time.Millisecond)
				}
			})
		})
	})
}
```
This one-line change should fix the issue!